### PR TITLE
Organize database assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# OpenTrials PostgreSQL Structure
+
+Este repositório organiza os artefatos do banco de dados utilizado no futuro Registro Brasileiro de Ensaios Clínicos. O conteúdo foi estruturado para facilitar a manutenção de tabelas, procedures e dados de apoio.
+
+## Organização de diretórios
+
+- `database/tables/`: arquivos SQL contendo as definições de todas as tabelas, sequências e restrições.
+- `database/procedures/`: funções PL/pgSQL extraídas do dump original.
+- `database/populate/`: inserts e ajustes de sequência que povoam as tabelas.
+- `scripts/`: utilitários Python (comentados em inglês) para aplicar as alterações e controlar versionamento.
+
+## Scripts Python
+
+Todos os scripts foram escritos por **Diego Tostes** e aceitam parâmetros via linha de comando:
+
+- `scripts/create_tables.py`: executa os arquivos de `database/tables/` em ordem alfabética.
+- `scripts/create_procedures.py`: aplica as funções definidas em `database/procedures/`.
+- `scripts/populate_data.py`: insere os dados definidos em `database/populate/`.
+- `scripts/schema_versioning.py`: calcula hashes dos arquivos SQL para detectar alterações e persistir metadados na tabela `schema_version`.
+
+Os scripts utilizam `psycopg2` para conexão com PostgreSQL e carregam a configuração do banco por variáveis de ambiente (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`) ou por um arquivo JSON informado via `--config`.
+
+### Exemplo de uso
+
+```bash
+python scripts/create_tables.py
+python scripts/create_procedures.py
+python scripts/populate_data.py
+python scripts/schema_versioning.py database/tables database/procedures database/populate --record
+```
+
+## Dump original
+
+O arquivo `dump_com_inserts.sql` permanece disponível como referência integral do estado inicial do banco.

--- a/database/populate/ct.sql
+++ b/database/populate/ct.sql
@@ -1,0 +1,15 @@
+-- Data for Name: ct; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.ct VALUES (3, NULL, 'CT001', 1, 'Estudo de teste', 'Estudo de teste', 'Estudo científico de teste', 'Estudo científico de teste', 1, '2025-01-01', 'https://example.com/ct001');
+
+
+--
+
+-- Name: ct_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_id_seq', 3, true);
+
+
+--

--- a/database/populate/ct_attachments.sql
+++ b/database/populate/ct_attachments.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_attachments; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_attachments_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_attachments_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_contact.sql
+++ b/database/populate/ct_contact.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_contact; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_contact_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_contact_id_seq', 1, true);
+
+
+--

--- a/database/populate/ct_country_of_recruitment.sql
+++ b/database/populate/ct_country_of_recruitment.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_country_of_recruitment; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_country_of_recruitment_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_country_of_recruitment_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_data_sharing.sql
+++ b/database/populate/ct_data_sharing.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_data_sharing; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_data_sharing_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_data_sharing_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_editor.sql
+++ b/database/populate/ct_editor.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_editor; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_editor_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_editor_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_health_condition_problem_study.sql
+++ b/database/populate/ct_health_condition_problem_study.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_health_condition_problem_study; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_health_condition_problem_study_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_health_condition_problem_study_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_institutions.sql
+++ b/database/populate/ct_institutions.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_institutions; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_institutions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_institutions_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_intervention.sql
+++ b/database/populate/ct_intervention.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_intervention; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_intervention_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_intervention_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_intervention_descriptor.sql
+++ b/database/populate/ct_intervention_descriptor.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_intervention_descriptor; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_intervention_descriptor_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_intervention_descriptor_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_outcome.sql
+++ b/database/populate/ct_outcome.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_outcome; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_outcome_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_outcome_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_recruitment.sql
+++ b/database/populate/ct_recruitment.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_recruitment; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_recruitment_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_recruitment_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_results.sql
+++ b/database/populate/ct_results.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_results; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_results_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_results_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_secondary_identify_numbers.sql
+++ b/database/populate/ct_secondary_identify_numbers.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_secondary_identify_numbers; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_secondary_identify_numbers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_secondary_identify_numbers_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_source_monetary_material_support.sql
+++ b/database/populate/ct_source_monetary_material_support.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_source_monetary_material_support; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_source_monetary_material_support_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_source_monetary_material_support_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_sponsor.sql
+++ b/database/populate/ct_sponsor.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_sponsor; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_sponsor_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_sponsor_id_seq', 1, false);
+
+
+--

--- a/database/populate/ct_study_type.sql
+++ b/database/populate/ct_study_type.sql
@@ -1,0 +1,14 @@
+-- Data for Name: ct_study_type; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: ct_study_type_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ct_study_type_id_seq', 1, false);
+
+
+--

--- a/database/populate/research_institutions.sql
+++ b/database/populate/research_institutions.sql
@@ -1,0 +1,14 @@
+-- Data for Name: research_institutions; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: research_institutions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.research_institutions_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_attachment_type.sql
+++ b/database/populate/vocabulary_attachment_type.sql
@@ -1,0 +1,16 @@
+-- Data for Name: vocabulary_attachment_type; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_attachment_type VALUES (1, 'Approved Opinion', 'Parecer Aprovado', 'Opinión Aprobada', true);
+INSERT INTO public.vocabulary_attachment_type VALUES (2, 'Other', 'Outro', 'Otro', true);
+
+
+--
+
+-- Name: vocabulary_attachment_type_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_attachment_type_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_country.sql
+++ b/database/populate/vocabulary_country.sql
@@ -1,0 +1,14 @@
+-- Data for Name: vocabulary_country; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: vocabulary_country_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_country_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_data_sharing_plan.sql
+++ b/database/populate/vocabulary_data_sharing_plan.sql
@@ -1,0 +1,16 @@
+-- Data for Name: vocabulary_data_sharing_plan; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_data_sharing_plan VALUES (1, 'Yes', 'Sim', 'Si', true);
+INSERT INTO public.vocabulary_data_sharing_plan VALUES (2, 'No', 'Não', 'No', true);
+
+
+--
+
+-- Name: vocabulary_data_sharing_plan_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_data_sharing_plan_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_health_condition_code_type.sql
+++ b/database/populate/vocabulary_health_condition_code_type.sql
@@ -1,0 +1,16 @@
+-- Data for Name: vocabulary_health_condition_code_type; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_health_condition_code_type VALUES (1, NULL, NULL, NULL, 'general', 'geral', 'geral', true);
+INSERT INTO public.vocabulary_health_condition_code_type VALUES (2, NULL, NULL, NULL, 'specific', 'especifico', 'especifico', true);
+
+
+--
+
+-- Name: vocabulary_health_condition_code_type_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_health_condition_code_type_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_health_condition_code_vocabulary.sql
+++ b/database/populate/vocabulary_health_condition_code_vocabulary.sql
@@ -1,0 +1,16 @@
+-- Data for Name: vocabulary_health_condition_code_vocabulary; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_health_condition_code_vocabulary VALUES (1, 'CID-10', NULL, NULL, true);
+INSERT INTO public.vocabulary_health_condition_code_vocabulary VALUES (2, 'DeCS', NULL, NULL, true);
+
+
+--
+
+-- Name: vocabulary_health_condition_code_vocabulary_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_health_condition_code_vocabulary_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_institution.sql
+++ b/database/populate/vocabulary_institution.sql
@@ -1,0 +1,14 @@
+-- Data for Name: vocabulary_institution; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+
+-- Name: vocabulary_institution_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_institution_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_institution_type.sql
+++ b/database/populate/vocabulary_institution_type.sql
@@ -1,0 +1,22 @@
+-- Data for Name: vocabulary_institution_type; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_institution_type VALUES (1, 'Clinical Research Network', 'Rede de Pesquisa Clínica', 'Rede de Pesquisa Clínica', true);
+INSERT INTO public.vocabulary_institution_type VALUES (2, 'Federal Agency', 'Agência Federal', 'Agência Federal', true);
+INSERT INTO public.vocabulary_institution_type VALUES (3, 'Industry', 'Indústria', 'Indústria', true);
+INSERT INTO public.vocabulary_institution_type VALUES (4, 'Ministery of Health', 'Ministério da Saúde', 'Ministério da Saúde', true);
+INSERT INTO public.vocabulary_institution_type VALUES (5, 'Non-governnamental Agency', 'Agência não governamental', 'Agência não governamental', true);
+INSERT INTO public.vocabulary_institution_type VALUES (6, 'State Research Support Agency', 'Agência de Fomento à Pesquisa', 'Agência de Fomento à Pesquisa', true);
+INSERT INTO public.vocabulary_institution_type VALUES (7, 'Higher Education Institution', 'Instituição de Ensino Superior', 'Instituição de Ensino Superior', true);
+INSERT INTO public.vocabulary_institution_type VALUES (8, 'Other', 'Outro', 'Otro', true);
+
+
+--
+
+-- Name: vocabulary_institution_type_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_institution_type_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_intervention.sql
+++ b/database/populate/vocabulary_intervention.sql
@@ -1,0 +1,16 @@
+-- Data for Name: vocabulary_intervention; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_intervention VALUES (1, 'Interventional', 'Intervencional', 'Intervencional', true);
+INSERT INTO public.vocabulary_intervention VALUES (2, 'Observational', 'Observacional', 'Observacional', true);
+
+
+--
+
+-- Name: vocabulary_intervention_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_intervention_id_seq', 1, true);
+
+
+--

--- a/database/populate/vocabulary_monetary_material_support_type.sql
+++ b/database/populate/vocabulary_monetary_material_support_type.sql
@@ -1,0 +1,18 @@
+-- Data for Name: vocabulary_monetary_material_support_type; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_monetary_material_support_type VALUES (13, NULL, NULL, NULL, 'funding agency', 'agencia de fomento', 'agencia fundadora', true);
+INSERT INTO public.vocabulary_monetary_material_support_type VALUES (14, NULL, NULL, NULL, 'foundation', 'fundação', 'fundação', true);
+INSERT INTO public.vocabulary_monetary_material_support_type VALUES (15, NULL, NULL, NULL, 'company', 'empresa', 'empresa', true);
+INSERT INTO public.vocabulary_monetary_material_support_type VALUES (16, NULL, NULL, NULL, 'institution', 'instituição', 'institución', true);
+
+
+--
+
+-- Name: vocabulary_monetary_material_support_type_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_monetary_material_support_type_id_seq', 16, true);
+
+
+--

--- a/database/populate/vocabulary_outcome_type.sql
+++ b/database/populate/vocabulary_outcome_type.sql
@@ -1,0 +1,16 @@
+-- Data for Name: vocabulary_outcome_type; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_outcome_type VALUES (1, 'Primary', 'Primário', 'Primario', true);
+INSERT INTO public.vocabulary_outcome_type VALUES (2, 'Secondary', 'Secundário', 'Secundario', true);
+
+
+--
+
+-- Name: vocabulary_outcome_type_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_outcome_type_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_recruitment_age_unit.sql
+++ b/database/populate/vocabulary_recruitment_age_unit.sql
@@ -1,0 +1,16 @@
+-- Data for Name: vocabulary_recruitment_age_unit; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_recruitment_age_unit VALUES (1, 'Y', 'Year', 'Ano', 'Año', true);
+INSERT INTO public.vocabulary_recruitment_age_unit VALUES (2, 'M', 'Month', 'Mês', 'Mes', true);
+
+
+--
+
+-- Name: vocabulary_recruitment_age_unit_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_recruitment_age_unit_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_recruitment_status.sql
+++ b/database/populate/vocabulary_recruitment_status.sql
@@ -1,0 +1,18 @@
+-- Data for Name: vocabulary_recruitment_status; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_recruitment_status VALUES (1, 'Not yet recruiting', 'Ainda não recrutando', 'Aún no reclutando', true);
+INSERT INTO public.vocabulary_recruitment_status VALUES (2, 'Recruiting', 'Recrutando', 'Reclutando', true);
+INSERT INTO public.vocabulary_recruitment_status VALUES (3, 'Completed', 'Concluído', 'Completado', true);
+INSERT INTO public.vocabulary_recruitment_status VALUES (4, 'Terminated', 'Encerrado', 'Terminado', true);
+
+
+--
+
+-- Name: vocabulary_recruitment_status_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_recruitment_status_id_seq', 4, true);
+
+
+--

--- a/database/populate/vocabulary_secondary_identify_type.sql
+++ b/database/populate/vocabulary_secondary_identify_type.sql
@@ -1,0 +1,18 @@
+-- Data for Name: vocabulary_secondary_identify_type; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_secondary_identify_type VALUES (1, NULL, NULL, NULL, 'CAAE', 'CAAE', 'CAAE', true);
+INSERT INTO public.vocabulary_secondary_identify_type VALUES (2, NULL, NULL, NULL, 'Universal Trial Number (UTN)', 'Número Universal de Ensaio Clínico (UTN)', 'Universal Trial Number (UTN)', true);
+INSERT INTO public.vocabulary_secondary_identify_type VALUES (3, NULL, NULL, NULL, 'Research Ethics Committee', 'Comitê de Ética em Pesquisa (CEP)', 'Comité de Ética en Investigación', true);
+INSERT INTO public.vocabulary_secondary_identify_type VALUES (4, NULL, NULL, NULL, 'Other', 'Outros', 'Otros', true);
+
+
+--
+
+-- Name: vocabulary_secondary_identify_type_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_secondary_identify_type_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_study_alocation.sql
+++ b/database/populate/vocabulary_study_alocation.sql
@@ -1,0 +1,18 @@
+-- Data for Name: vocabulary_study_alocation; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_study_alocation VALUES (1, 'Non-randomized controlled', 'Controlado não randomizado', 'Controlado no aleatorio', true);
+INSERT INTO public.vocabulary_study_alocation VALUES (2, 'Randomized Controlled', 'Randomizado Controlado', 'Controlado Aleatorio', true);
+INSERT INTO public.vocabulary_study_alocation VALUES (3, 'Single Arm', 'Braço Único', 'Un Solo Brazo', true);
+INSERT INTO public.vocabulary_study_alocation VALUES (4, 'N/A', 'N/A', 'N/A', true);
+
+
+--
+
+-- Name: vocabulary_study_alocation_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_study_alocation_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_study_type_expanded_access.sql
+++ b/database/populate/vocabulary_study_type_expanded_access.sql
@@ -1,0 +1,17 @@
+-- Data for Name: vocabulary_study_type_expanded_access; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_study_type_expanded_access VALUES (1, 'Unknown', 'Desconhecido', 'Desconocido', true);
+INSERT INTO public.vocabulary_study_type_expanded_access VALUES (2, 'Yes', 'Sim', 'Si', true);
+INSERT INTO public.vocabulary_study_type_expanded_access VALUES (3, 'No', 'Não', 'No', true);
+
+
+--
+
+-- Name: vocabulary_study_type_expanded_access_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_study_type_expanded_access_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_study_type_intervention_assignment.sql
+++ b/database/populate/vocabulary_study_type_intervention_assignment.sql
@@ -1,0 +1,19 @@
+-- Data for Name: vocabulary_study_type_intervention_assignment; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_study_type_intervention_assignment VALUES (1, 'Single Group', 'Grupo Único', 'Grupo Único', true);
+INSERT INTO public.vocabulary_study_type_intervention_assignment VALUES (2, 'Parallel', 'Paralelo', 'Paralelo', true);
+INSERT INTO public.vocabulary_study_type_intervention_assignment VALUES (3, 'Crusader', 'Cruzado', 'Cruzado', true);
+INSERT INTO public.vocabulary_study_type_intervention_assignment VALUES (4, 'Factorial', 'Fatorial', 'Factorial', true);
+INSERT INTO public.vocabulary_study_type_intervention_assignment VALUES (5, 'Other', 'Outros', 'Otros', true);
+
+
+--
+
+-- Name: vocabulary_study_type_intervention_assignment_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_study_type_intervention_assignment_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_study_type_masking.sql
+++ b/database/populate/vocabulary_study_type_masking.sql
@@ -1,0 +1,19 @@
+-- Data for Name: vocabulary_study_type_masking; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_study_type_masking VALUES (1, 'Open', 'Aberto', 'Abierto', true);
+INSERT INTO public.vocabulary_study_type_masking VALUES (2, 'Single-blind', 'Cego', 'Ciego', true);
+INSERT INTO public.vocabulary_study_type_masking VALUES (3, 'Double-blind', 'Duplo Cego', 'Doble Ciego', true);
+INSERT INTO public.vocabulary_study_type_masking VALUES (4, 'Triple-blind', 'Triplo Cego', 'Triple Ciego', true);
+INSERT INTO public.vocabulary_study_type_masking VALUES (5, 'N/A', 'N/A', 'N/A', true);
+
+
+--
+
+-- Name: vocabulary_study_type_masking_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_study_type_masking_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_study_type_obs_study_design.sql
+++ b/database/populate/vocabulary_study_type_obs_study_design.sql
@@ -1,0 +1,20 @@
+-- Data for Name: vocabulary_study_type_obs_study_design; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_study_type_obs_study_design VALUES (1, 'Diagnosis', 'Diagnóstico', 'Diagnóstico', true);
+INSERT INTO public.vocabulary_study_type_obs_study_design VALUES (2, 'Etiological', 'Etiológico', 'Etiológico', true);
+INSERT INTO public.vocabulary_study_type_obs_study_design VALUES (3, 'Prognosis', 'Prognóstico', 'Prognóstico', true);
+INSERT INTO public.vocabulary_study_type_obs_study_design VALUES (4, 'Prevenção', 'Prevenção', 'Prevención', true);
+INSERT INTO public.vocabulary_study_type_obs_study_design VALUES (5, 'Treatment', 'Tratamento', 'Tratamiento', true);
+INSERT INTO public.vocabulary_study_type_obs_study_design VALUES (6, 'Other', 'Outro', 'Otro', true);
+
+
+--
+
+-- Name: vocabulary_study_type_obs_study_design_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_study_type_obs_study_design_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_study_type_phase.sql
+++ b/database/populate/vocabulary_study_type_phase.sql
@@ -1,0 +1,22 @@
+-- Data for Name: vocabulary_study_type_phase; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_study_type_phase VALUES (1, 'N/A', 'N/A', 'N/A', true);
+INSERT INTO public.vocabulary_study_type_phase VALUES (2, '1', '1', '1', true);
+INSERT INTO public.vocabulary_study_type_phase VALUES (3, '1-2', '1-2', '1-2', true);
+INSERT INTO public.vocabulary_study_type_phase VALUES (4, '2', '2', '2', true);
+INSERT INTO public.vocabulary_study_type_phase VALUES (5, '2-3', '2-3', '2-3', true);
+INSERT INTO public.vocabulary_study_type_phase VALUES (6, '3', '3', '3', true);
+INSERT INTO public.vocabulary_study_type_phase VALUES (7, '4', '4', '4', true);
+INSERT INTO public.vocabulary_study_type_phase VALUES (8, '0', '0', '0', true);
+
+
+--
+
+-- Name: vocabulary_study_type_phase_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_study_type_phase_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_study_type_purpose.sql
+++ b/database/populate/vocabulary_study_type_purpose.sql
@@ -1,0 +1,20 @@
+-- Data for Name: vocabulary_study_type_purpose; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_study_type_purpose VALUES (1, 'Diagnostic', 'Diagnóstico', 'Diagnóstico', true);
+INSERT INTO public.vocabulary_study_type_purpose VALUES (2, 'Etiological', 'Etiológico', 'Etiológico', true);
+INSERT INTO public.vocabulary_study_type_purpose VALUES (3, 'Prognostic', 'Prognostico', 'Prognostico', true);
+INSERT INTO public.vocabulary_study_type_purpose VALUES (4, 'Prevention', 'Prevenção', 'Prevención', true);
+INSERT INTO public.vocabulary_study_type_purpose VALUES (5, 'Treatment', 'Tratamento', 'Tratamiento', true);
+INSERT INTO public.vocabulary_study_type_purpose VALUES (6, 'Other', 'Outro', 'Otro', true);
+
+
+--
+
+-- Name: vocabulary_study_type_purpose_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_study_type_purpose_id_seq', 1, false);
+
+
+--

--- a/database/populate/vocabulary_study_type_temporality.sql
+++ b/database/populate/vocabulary_study_type_temporality.sql
@@ -1,0 +1,21 @@
+-- Data for Name: vocabulary_study_type_temporality; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.vocabulary_study_type_temporality VALUES (1, 'N/A', 'N/A', 'N/A', true);
+INSERT INTO public.vocabulary_study_type_temporality VALUES (2, 'Prospective', 'Prospectivo', 'Futuro', true);
+INSERT INTO public.vocabulary_study_type_temporality VALUES (3, 'Retrospective', 'Retrospectivo', 'Retrospectivo', true);
+INSERT INTO public.vocabulary_study_type_temporality VALUES (4, 'Retrospective and Prospective', 'Retrospectivo e Prospectivo', 'Retrospectiva y Prospectiva', true);
+INSERT INTO public.vocabulary_study_type_temporality VALUES (5, 'Transversal', 'Transversal', 'Transversal', true);
+INSERT INTO public.vocabulary_study_type_temporality VALUES (6, 'Longitudinal', 'Longitudinal', 'Longitudinal', true);
+INSERT INTO public.vocabulary_study_type_temporality VALUES (7, 'Other', 'Outro', 'Otro', true);
+
+
+--
+
+-- Name: vocabulary_study_type_temporality_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.vocabulary_study_type_temporality_id_seq', 1, false);
+
+
+--

--- a/database/procedures/generate_register_code.sql
+++ b/database/procedures/generate_register_code.sql
@@ -1,0 +1,27 @@
+-- Name: generate_register_code(character varying); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.generate_register_code(prefix character varying) RETURNS character varying
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    new_code VARCHAR(30);
+BEGIN
+    LOOP
+        -- Gerar um código aleatório
+        new_code := prefix || '-' || substr(md5(random()::text || clock_timestamp()::text), 1, 6);
+
+        -- Verificar se o código já existe na tabela ct
+        EXIT WHEN NOT EXISTS (
+            SELECT 1 FROM ct WHERE register_id ILIKE new_code
+        );
+
+        -- Se o código existir, gerar outro
+    END LOOP;
+
+    RETURN new_code;
+END;
+$$;
+
+
+--

--- a/database/procedures/get_full_trial_json_auto_multilang.sql
+++ b/database/procedures/get_full_trial_json_auto_multilang.sql
@@ -1,0 +1,80 @@
+-- Name: get_full_trial_json_auto_multilang(integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.get_full_trial_json_auto_multilang(p_ct_id integer) RETURNS jsonb
+    LANGUAGE plpgsql
+    AS $_$
+DECLARE
+    result JSONB := '{}'::jsonb;
+    ct_data JSONB;
+    rel RECORD;
+    sub_data JSONB;
+    sql_query TEXT;
+BEGIN
+    -- 1. Obter dados do CT principal com tradução de vocabulário
+    SELECT jsonb_build_object(
+        'id', c.id,
+        'register_id', c.register_id,
+        'public_title', c.public_title,
+        'public_title_native', c.public_title_native,
+        'scientific_title', c.scientific_title,
+        'scientific_title_native', c.scientific_title_native,
+        'completion_date', c.completion_date,
+        'trial_url', c.trial_url,
+        'study_type', jsonb_build_object(
+            'id', vi.id,
+            'pt', vi.choice_pt,
+            'en', vi.choice_en
+        ),
+        'recruitment_status', jsonb_build_object(
+            'id', vrs.id,
+            'pt', vrs.choice_pt,
+            'en', vrs.choice_en
+        )
+    )
+    INTO ct_data
+    FROM ct c
+    LEFT JOIN vocabulary_intervention vi ON vi.id = c.study_type
+    LEFT JOIN vocabulary_recruitment_status vrs ON vrs.id = c.recruitment_status
+    WHERE c.id = p_ct_id;
+
+    -- 2. Adiciona o CT ao resultado
+    result := jsonb_build_object('ct', ct_data);
+
+    -- 3. Descobre todas as tabelas que se relacionam com ct(trial_id)
+    FOR rel IN
+        SELECT tc.table_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+            ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+            AND kcu.column_name = 'trial_id'
+            AND tc.table_schema = 'public'
+            AND tc.table_name != 'ct'
+    LOOP
+        -- 4. Monta consulta dinâmica simples para pegar os registros relacionados
+        sql_query := format(
+            'SELECT jsonb_agg(to_jsonb(t)) FROM %I t WHERE trial_id = $1',
+            rel.table_name
+        );
+
+        EXECUTE sql_query INTO sub_data USING p_ct_id;
+
+        IF sub_data IS NULL THEN
+            sub_data := '[]'::jsonb;
+        END IF;
+
+        -- 5. Adiciona ao resultado
+        result := result || jsonb_build_object(rel.table_name, sub_data);
+    END LOOP;
+
+    RETURN result;
+END;
+$_$;
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--

--- a/database/tables/ct.sql
+++ b/database/tables/ct.sql
@@ -1,0 +1,76 @@
+-- Name: ct; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct (
+    id integer NOT NULL,
+    creator_id integer,
+    register_id character varying(100),
+    study_type integer,
+    public_title character varying(255) NOT NULL,
+    public_title_native character varying(255) NOT NULL,
+    scientific_title character varying(255) NOT NULL,
+    scientific_title_native character varying(255) NOT NULL,
+    recruitment_status integer,
+    completion_date date,
+    trial_url character varying(255)
+);
+
+
+--
+
+-- Name: ct_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_id_seq OWNED BY public.ct.id;
+
+
+--
+
+-- Name: ct id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct ALTER COLUMN id SET DEFAULT nextval('public.ct_id_seq'::regclass);
+
+
+--
+
+-- Name: ct ct_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct
+    ADD CONSTRAINT ct_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct ct_recruitment_status_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct
+    ADD CONSTRAINT ct_recruitment_status_fkey FOREIGN KEY (recruitment_status) REFERENCES public.vocabulary_recruitment_status(id);
+
+
+--
+
+-- Name: ct ct_study_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct
+    ADD CONSTRAINT ct_study_type_fkey FOREIGN KEY (study_type) REFERENCES public.vocabulary_intervention(id);
+
+
+--

--- a/database/tables/ct_attachments.sql
+++ b/database/tables/ct_attachments.sql
@@ -1,0 +1,71 @@
+-- Name: ct_attachments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_attachments (
+    id integer NOT NULL,
+    trial_id integer,
+    attachment_type integer,
+    is_public boolean DEFAULT false,
+    attachment_link character varying(255),
+    attachment character varying(255)
+);
+
+
+--
+
+-- Name: ct_attachments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_attachments_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_attachments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_attachments_id_seq OWNED BY public.ct_attachments.id;
+
+
+--
+
+-- Name: ct_attachments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_attachments ALTER COLUMN id SET DEFAULT nextval('public.ct_attachments_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_attachments ct_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_attachments
+    ADD CONSTRAINT ct_attachments_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_attachments ct_attachments_attachment_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_attachments
+    ADD CONSTRAINT ct_attachments_attachment_type_fkey FOREIGN KEY (attachment_type) REFERENCES public.vocabulary_attachment_type(id);
+
+
+--
+
+-- Name: ct_attachments ct_attachments_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_attachments
+    ADD CONSTRAINT ct_attachments_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_contact.sql
+++ b/database/tables/ct_contact.sql
@@ -1,0 +1,72 @@
+-- Name: ct_contact; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_contact (
+    id integer NOT NULL,
+    trial_id integer,
+    first_name character varying(255),
+    middle_name character varying(255),
+    last_name character varying(255),
+    address text,
+    city character varying(100),
+    country character varying(100),
+    zip_code character varying(20),
+    telephone character varying(50),
+    email character varying(255),
+    affiliation integer,
+    is_public_contact boolean DEFAULT false,
+    is_scientific_contact boolean DEFAULT false,
+    is_site_contact boolean DEFAULT false,
+    is_ethic_contact boolean DEFAULT false
+);
+
+
+--
+
+-- Name: ct_contact_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_contact_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_contact_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_contact_id_seq OWNED BY public.ct_contact.id;
+
+
+--
+
+-- Name: ct_contact id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_contact ALTER COLUMN id SET DEFAULT nextval('public.ct_contact_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_contact ct_contact_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_contact
+    ADD CONSTRAINT ct_contact_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_contact ct_contact_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_contact
+    ADD CONSTRAINT ct_contact_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_country_of_recruitment.sql
+++ b/database/tables/ct_country_of_recruitment.sql
@@ -1,0 +1,59 @@
+-- Name: ct_country_of_recruitment; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_country_of_recruitment (
+    id integer NOT NULL,
+    trial_id integer,
+    country character varying(100)
+);
+
+
+--
+
+-- Name: ct_country_of_recruitment_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_country_of_recruitment_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_country_of_recruitment_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_country_of_recruitment_id_seq OWNED BY public.ct_country_of_recruitment.id;
+
+
+--
+
+-- Name: ct_country_of_recruitment id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_country_of_recruitment ALTER COLUMN id SET DEFAULT nextval('public.ct_country_of_recruitment_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_country_of_recruitment ct_country_of_recruitment_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_country_of_recruitment
+    ADD CONSTRAINT ct_country_of_recruitment_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_country_of_recruitment ct_country_of_recruitment_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_country_of_recruitment
+    ADD CONSTRAINT ct_country_of_recruitment_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_data_sharing.sql
+++ b/database/tables/ct_data_sharing.sql
@@ -1,0 +1,70 @@
+-- Name: ct_data_sharing; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_data_sharing (
+    id integer NOT NULL,
+    trial_id integer,
+    data_sharing_plan integer,
+    data_sharing_description text,
+    data_sharing_description_native text
+);
+
+
+--
+
+-- Name: ct_data_sharing_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_data_sharing_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_data_sharing_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_data_sharing_id_seq OWNED BY public.ct_data_sharing.id;
+
+
+--
+
+-- Name: ct_data_sharing id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_data_sharing ALTER COLUMN id SET DEFAULT nextval('public.ct_data_sharing_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_data_sharing ct_data_sharing_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_data_sharing
+    ADD CONSTRAINT ct_data_sharing_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_data_sharing ct_data_sharing_data_sharing_plan_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_data_sharing
+    ADD CONSTRAINT ct_data_sharing_data_sharing_plan_fkey FOREIGN KEY (data_sharing_plan) REFERENCES public.vocabulary_data_sharing_plan(id);
+
+
+--
+
+-- Name: ct_data_sharing ct_data_sharing_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_data_sharing
+    ADD CONSTRAINT ct_data_sharing_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_editor.sql
+++ b/database/tables/ct_editor.sql
@@ -1,0 +1,60 @@
+-- Name: ct_editor; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_editor (
+    id integer NOT NULL,
+    owner_id integer,
+    trial_id integer,
+    editor_id integer
+);
+
+
+--
+
+-- Name: ct_editor_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_editor_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_editor_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_editor_id_seq OWNED BY public.ct_editor.id;
+
+
+--
+
+-- Name: ct_editor id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_editor ALTER COLUMN id SET DEFAULT nextval('public.ct_editor_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_editor ct_editor_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_editor
+    ADD CONSTRAINT ct_editor_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_editor ct_editor_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_editor
+    ADD CONSTRAINT ct_editor_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_health_condition_problem_study.sql
+++ b/database/tables/ct_health_condition_problem_study.sql
@@ -1,0 +1,82 @@
+-- Name: ct_health_condition_problem_study; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_health_condition_problem_study (
+    id integer NOT NULL,
+    trial_id integer,
+    health_condition text,
+    health_condition_native text,
+    health_condition_code character varying(255),
+    health_condition_code_type integer,
+    health_condition_code_vocabulary integer,
+    health_condition_keyword character varying(255)
+);
+
+
+--
+
+-- Name: ct_health_condition_problem_study_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_health_condition_problem_study_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_health_condition_problem_study_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_health_condition_problem_study_id_seq OWNED BY public.ct_health_condition_problem_study.id;
+
+
+--
+
+-- Name: ct_health_condition_problem_study id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_health_condition_problem_study ALTER COLUMN id SET DEFAULT nextval('public.ct_health_condition_problem_study_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_health_condition_problem_study ct_health_condition_problem_study_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_health_condition_problem_study
+    ADD CONSTRAINT ct_health_condition_problem_study_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_health_condition_problem_study ct_health_condition_problem_s_health_condition_code_vocabu_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_health_condition_problem_study
+    ADD CONSTRAINT ct_health_condition_problem_s_health_condition_code_vocabu_fkey FOREIGN KEY (health_condition_code_vocabulary) REFERENCES public.vocabulary_health_condition_code_vocabulary(id);
+
+
+--
+
+-- Name: ct_health_condition_problem_study ct_health_condition_problem_stu_health_condition_code_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_health_condition_problem_study
+    ADD CONSTRAINT ct_health_condition_problem_stu_health_condition_code_type_fkey FOREIGN KEY (health_condition_code_type) REFERENCES public.vocabulary_health_condition_code_type(id);
+
+
+--
+
+-- Name: ct_health_condition_problem_study ct_health_condition_problem_study_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_health_condition_problem_study
+    ADD CONSTRAINT ct_health_condition_problem_study_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_institutions.sql
+++ b/database/tables/ct_institutions.sql
@@ -1,0 +1,82 @@
+-- Name: ct_institutions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_institutions (
+    id integer NOT NULL,
+    trial_id integer,
+    name character varying(255),
+    address text,
+    city character varying(255),
+    state character varying(255),
+    country integer,
+    type_id integer
+);
+
+
+--
+
+-- Name: ct_institutions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_institutions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_institutions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_institutions_id_seq OWNED BY public.ct_institutions.id;
+
+
+--
+
+-- Name: ct_institutions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_institutions ALTER COLUMN id SET DEFAULT nextval('public.ct_institutions_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_institutions ct_institutions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_institutions
+    ADD CONSTRAINT ct_institutions_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_institutions ct_institutions_country_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_institutions
+    ADD CONSTRAINT ct_institutions_country_fkey FOREIGN KEY (country) REFERENCES public.vocabulary_country(id);
+
+
+--
+
+-- Name: ct_institutions ct_institutions_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_institutions
+    ADD CONSTRAINT ct_institutions_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--
+
+-- Name: ct_institutions ct_institutions_type_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_institutions
+    ADD CONSTRAINT ct_institutions_type_id_fkey FOREIGN KEY (type_id) REFERENCES public.vocabulary_institution_type(id);
+
+
+--

--- a/database/tables/ct_intervention.sql
+++ b/database/tables/ct_intervention.sql
@@ -1,0 +1,69 @@
+-- Name: ct_intervention; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_intervention (
+    id integer NOT NULL,
+    trial_id integer,
+    intervention_description text,
+    intervention_description_pt text,
+    is_drug boolean DEFAULT false,
+    is_device boolean DEFAULT false,
+    is_biological_vacina boolean DEFAULT false,
+    is_procedure_surgery boolean DEFAULT false,
+    is_radiation boolean DEFAULT false,
+    is_behavioural boolean DEFAULT false,
+    is_genetics boolean DEFAULT false,
+    is_diatary_supplement boolean DEFAULT false,
+    is_other boolean DEFAULT false
+);
+
+
+--
+
+-- Name: ct_intervention_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_intervention_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_intervention_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_intervention_id_seq OWNED BY public.ct_intervention.id;
+
+
+--
+
+-- Name: ct_intervention id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_intervention ALTER COLUMN id SET DEFAULT nextval('public.ct_intervention_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_intervention ct_intervention_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_intervention
+    ADD CONSTRAINT ct_intervention_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_intervention ct_intervention_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_intervention
+    ADD CONSTRAINT ct_intervention_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_intervention_descriptor.sql
+++ b/database/tables/ct_intervention_descriptor.sql
@@ -1,0 +1,72 @@
+-- Name: ct_intervention_descriptor; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_intervention_descriptor (
+    id integer NOT NULL,
+    trial_id integer,
+    intervention_descriptor_type integer,
+    intervention_descriptor_vocabulary integer,
+    intervention_descriptor_code character varying(255),
+    intervention_descriptor character varying(255),
+    intervention_descriptor_pt character varying(255)
+);
+
+
+--
+
+-- Name: ct_intervention_descriptor_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_intervention_descriptor_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_intervention_descriptor_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_intervention_descriptor_id_seq OWNED BY public.ct_intervention_descriptor.id;
+
+
+--
+
+-- Name: ct_intervention_descriptor id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_intervention_descriptor ALTER COLUMN id SET DEFAULT nextval('public.ct_intervention_descriptor_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_intervention_descriptor ct_intervention_descriptor_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_intervention_descriptor
+    ADD CONSTRAINT ct_intervention_descriptor_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_intervention_descriptor ct_intervention_descriptor_intervention_descriptor_vocabul_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_intervention_descriptor
+    ADD CONSTRAINT ct_intervention_descriptor_intervention_descriptor_vocabul_fkey FOREIGN KEY (intervention_descriptor_vocabulary) REFERENCES public.vocabulary_health_condition_code_vocabulary(id);
+
+
+--
+
+-- Name: ct_intervention_descriptor ct_intervention_descriptor_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_intervention_descriptor
+    ADD CONSTRAINT ct_intervention_descriptor_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_outcome.sql
+++ b/database/tables/ct_outcome.sql
@@ -1,0 +1,75 @@
+-- Name: ct_outcome; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_outcome (
+    id integer NOT NULL,
+    trial_id integer,
+    outcome_type integer,
+    outcome_name character varying(255),
+    time_point character varying(255),
+    measure character varying(255),
+    objectives character varying(255),
+    endpoints character varying(255),
+    description text,
+    description_native text
+);
+
+
+--
+
+-- Name: ct_outcome_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_outcome_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_outcome_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_outcome_id_seq OWNED BY public.ct_outcome.id;
+
+
+--
+
+-- Name: ct_outcome id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_outcome ALTER COLUMN id SET DEFAULT nextval('public.ct_outcome_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_outcome ct_outcome_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_outcome
+    ADD CONSTRAINT ct_outcome_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_outcome ct_outcome_outcome_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_outcome
+    ADD CONSTRAINT ct_outcome_outcome_type_fkey FOREIGN KEY (outcome_type) REFERENCES public.vocabulary_outcome_type(id);
+
+
+--
+
+-- Name: ct_outcome ct_outcome_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_outcome
+    ADD CONSTRAINT ct_outcome_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_recruitment.sql
+++ b/database/tables/ct_recruitment.sql
@@ -1,0 +1,69 @@
+-- Name: ct_recruitment; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_recruitment (
+    id integer NOT NULL,
+    trial_id integer,
+    first_date_enrollment date,
+    last_date_enrollment date,
+    target_sample_size integer,
+    inclusion_criteria text,
+    inclusion_criteria_native text,
+    exclusion_criteria text,
+    exclusion_criteria_native text,
+    age_minimum integer,
+    unit_age_minimum character varying(50),
+    age_maximum integer,
+    unit_age_maximum character varying(50)
+);
+
+
+--
+
+-- Name: ct_recruitment_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_recruitment_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_recruitment_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_recruitment_id_seq OWNED BY public.ct_recruitment.id;
+
+
+--
+
+-- Name: ct_recruitment id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_recruitment ALTER COLUMN id SET DEFAULT nextval('public.ct_recruitment_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_recruitment ct_recruitment_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_recruitment
+    ADD CONSTRAINT ct_recruitment_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_recruitment ct_recruitment_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_recruitment
+    ADD CONSTRAINT ct_recruitment_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_results.sql
+++ b/database/tables/ct_results.sql
@@ -1,0 +1,71 @@
+-- Name: ct_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_results (
+    id integer NOT NULL,
+    trial_id integer,
+    publication_date date,
+    results_url character varying(255),
+    baseline text,
+    baseline_native text,
+    participants_flow text,
+    participants_flow_native text,
+    adverse_events text,
+    adverse_events_native text,
+    outcome_mesure text,
+    outcome_mesure_native text,
+    protocol_url character varying(255),
+    sumary_results text,
+    sumary_results_native text
+);
+
+
+--
+
+-- Name: ct_results_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_results_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_results_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_results_id_seq OWNED BY public.ct_results.id;
+
+
+--
+
+-- Name: ct_results id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_results ALTER COLUMN id SET DEFAULT nextval('public.ct_results_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_results ct_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_results
+    ADD CONSTRAINT ct_results_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_results ct_results_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_results
+    ADD CONSTRAINT ct_results_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_secondary_identify_numbers.sql
+++ b/database/tables/ct_secondary_identify_numbers.sql
@@ -1,0 +1,70 @@
+-- Name: ct_secondary_identify_numbers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_secondary_identify_numbers (
+    id integer NOT NULL,
+    trial_id integer,
+    identify_type integer,
+    identify_code character varying(255),
+    issuing_institution character varying(255)
+);
+
+
+--
+
+-- Name: ct_secondary_identify_numbers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_secondary_identify_numbers_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_secondary_identify_numbers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_secondary_identify_numbers_id_seq OWNED BY public.ct_secondary_identify_numbers.id;
+
+
+--
+
+-- Name: ct_secondary_identify_numbers id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_secondary_identify_numbers ALTER COLUMN id SET DEFAULT nextval('public.ct_secondary_identify_numbers_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_secondary_identify_numbers ct_secondary_identify_numbers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_secondary_identify_numbers
+    ADD CONSTRAINT ct_secondary_identify_numbers_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_secondary_identify_numbers ct_secondary_identify_numbers_identify_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_secondary_identify_numbers
+    ADD CONSTRAINT ct_secondary_identify_numbers_identify_type_fkey FOREIGN KEY (identify_type) REFERENCES public.vocabulary_secondary_identify_type(id);
+
+
+--
+
+-- Name: ct_secondary_identify_numbers ct_secondary_identify_numbers_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_secondary_identify_numbers
+    ADD CONSTRAINT ct_secondary_identify_numbers_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_source_monetary_material_support.sql
+++ b/database/tables/ct_source_monetary_material_support.sql
@@ -1,0 +1,70 @@
+-- Name: ct_source_monetary_material_support; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_source_monetary_material_support (
+    id integer NOT NULL,
+    trial_id integer,
+    source_name character varying(255),
+    source_type character varying(255),
+    support_type integer
+);
+
+
+--
+
+-- Name: ct_source_monetary_material_support_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_source_monetary_material_support_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_source_monetary_material_support_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_source_monetary_material_support_id_seq OWNED BY public.ct_source_monetary_material_support.id;
+
+
+--
+
+-- Name: ct_source_monetary_material_support id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_source_monetary_material_support ALTER COLUMN id SET DEFAULT nextval('public.ct_source_monetary_material_support_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_source_monetary_material_support ct_source_monetary_material_support_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_source_monetary_material_support
+    ADD CONSTRAINT ct_source_monetary_material_support_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_source_monetary_material_support ct_source_monetary_material_support_support_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_source_monetary_material_support
+    ADD CONSTRAINT ct_source_monetary_material_support_support_type_fkey FOREIGN KEY (support_type) REFERENCES public.vocabulary_monetary_material_support_type(id);
+
+
+--
+
+-- Name: ct_source_monetary_material_support ct_source_monetary_material_support_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_source_monetary_material_support
+    ADD CONSTRAINT ct_source_monetary_material_support_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_sponsor.sql
+++ b/database/tables/ct_sponsor.sql
@@ -1,0 +1,63 @@
+-- Name: ct_sponsor; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_sponsor (
+    id integer NOT NULL,
+    trial_id integer,
+    institution_id integer,
+    is_primary_sponsor boolean DEFAULT false,
+    is_secondary_sponsor boolean DEFAULT false,
+    is_monetary_support boolean DEFAULT false,
+    source_type character varying(255)
+);
+
+
+--
+
+-- Name: ct_sponsor_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_sponsor_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_sponsor_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_sponsor_id_seq OWNED BY public.ct_sponsor.id;
+
+
+--
+
+-- Name: ct_sponsor id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_sponsor ALTER COLUMN id SET DEFAULT nextval('public.ct_sponsor_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_sponsor ct_sponsor_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_sponsor
+    ADD CONSTRAINT ct_sponsor_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_sponsor ct_sponsor_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_sponsor
+    ADD CONSTRAINT ct_sponsor_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/ct_study_type.sql
+++ b/database/tables/ct_study_type.sql
@@ -1,0 +1,139 @@
+-- Name: ct_study_type; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ct_study_type (
+    id integer NOT NULL,
+    trial_id integer,
+    expanded_access_program integer,
+    purpose integer,
+    intervention_assignment integer,
+    number_of_arms integer,
+    masking_type integer,
+    alocation_type integer,
+    study_phase integer,
+    observational_study_design integer,
+    temporality integer
+);
+
+
+--
+
+-- Name: ct_study_type_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ct_study_type_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: ct_study_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ct_study_type_id_seq OWNED BY public.ct_study_type.id;
+
+
+--
+
+-- Name: ct_study_type id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type ALTER COLUMN id SET DEFAULT nextval('public.ct_study_type_id_seq'::regclass);
+
+
+--
+
+-- Name: ct_study_type ct_study_type_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type
+    ADD CONSTRAINT ct_study_type_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: ct_study_type ct_study_type_alocation_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type
+    ADD CONSTRAINT ct_study_type_alocation_type_fkey FOREIGN KEY (alocation_type) REFERENCES public.vocabulary_study_alocation(id);
+
+
+--
+
+-- Name: ct_study_type ct_study_type_expanded_access_program_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type
+    ADD CONSTRAINT ct_study_type_expanded_access_program_fkey FOREIGN KEY (expanded_access_program) REFERENCES public.vocabulary_study_type_expanded_access(id);
+
+
+--
+
+-- Name: ct_study_type ct_study_type_intervention_assignment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type
+    ADD CONSTRAINT ct_study_type_intervention_assignment_fkey FOREIGN KEY (intervention_assignment) REFERENCES public.vocabulary_study_type_intervention_assignment(id);
+
+
+--
+
+-- Name: ct_study_type ct_study_type_masking_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type
+    ADD CONSTRAINT ct_study_type_masking_type_fkey FOREIGN KEY (masking_type) REFERENCES public.vocabulary_study_type_masking(id);
+
+
+--
+
+-- Name: ct_study_type ct_study_type_observational_study_design_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type
+    ADD CONSTRAINT ct_study_type_observational_study_design_fkey FOREIGN KEY (observational_study_design) REFERENCES public.vocabulary_study_type_obs_study_design(id);
+
+
+--
+
+-- Name: ct_study_type ct_study_type_purpose_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type
+    ADD CONSTRAINT ct_study_type_purpose_fkey FOREIGN KEY (purpose) REFERENCES public.vocabulary_study_type_purpose(id);
+
+
+--
+
+-- Name: ct_study_type ct_study_type_study_phase_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type
+    ADD CONSTRAINT ct_study_type_study_phase_fkey FOREIGN KEY (study_phase) REFERENCES public.vocabulary_study_type_phase(id);
+
+
+--
+
+-- Name: ct_study_type ct_study_type_temporality_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type
+    ADD CONSTRAINT ct_study_type_temporality_fkey FOREIGN KEY (temporality) REFERENCES public.vocabulary_study_type_temporality(id);
+
+
+--
+
+-- Name: ct_study_type ct_study_type_trial_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ct_study_type
+    ADD CONSTRAINT ct_study_type_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES public.ct(id);
+
+
+--

--- a/database/tables/research_institutions.sql
+++ b/database/tables/research_institutions.sql
@@ -1,0 +1,75 @@
+-- Name: research_institutions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.research_institutions (
+    id integer NOT NULL,
+    name character varying(255),
+    address text,
+    city character varying(255),
+    state character varying(255),
+    country_id integer,
+    type_id integer,
+    approved boolean DEFAULT false
+);
+
+
+--
+
+-- Name: research_institutions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.research_institutions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: research_institutions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.research_institutions_id_seq OWNED BY public.research_institutions.id;
+
+
+--
+
+-- Name: research_institutions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.research_institutions ALTER COLUMN id SET DEFAULT nextval('public.research_institutions_id_seq'::regclass);
+
+
+--
+
+-- Name: research_institutions research_institutions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.research_institutions
+    ADD CONSTRAINT research_institutions_pkey PRIMARY KEY (id);
+
+
+--
+
+-- Name: research_institutions research_institutions_country_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.research_institutions
+    ADD CONSTRAINT research_institutions_country_id_fkey FOREIGN KEY (country_id) REFERENCES public.vocabulary_country(id);
+
+
+--
+
+-- Name: research_institutions research_institutions_type_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.research_institutions
+    ADD CONSTRAINT research_institutions_type_id_fkey FOREIGN KEY (type_id) REFERENCES public.vocabulary_institution_type(id);
+
+
+--
+-- PostgreSQL database dump complete
+--

--- a/database/tables/vocabulary_attachment_type.sql
+++ b/database/tables/vocabulary_attachment_type.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_attachment_type; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_attachment_type (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_attachment_type_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_attachment_type_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_attachment_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_attachment_type_id_seq OWNED BY public.vocabulary_attachment_type.id;
+
+
+--
+
+-- Name: vocabulary_attachment_type id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_attachment_type ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_attachment_type_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_attachment_type vocabulary_attachment_type_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_attachment_type
+    ADD CONSTRAINT vocabulary_attachment_type_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_country.sql
+++ b/database/tables/vocabulary_country.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_country; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_country (
+    id integer NOT NULL,
+    country_en character varying(255),
+    country_pt character varying(255),
+    country_es character varying(255),
+    country_label character varying(255)
+);
+
+
+--
+
+-- Name: vocabulary_country_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_country_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_country_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_country_id_seq OWNED BY public.vocabulary_country.id;
+
+
+--
+
+-- Name: vocabulary_country id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_country ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_country_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_country vocabulary_country_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_country
+    ADD CONSTRAINT vocabulary_country_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_data_sharing_plan.sql
+++ b/database/tables/vocabulary_data_sharing_plan.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_data_sharing_plan; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_data_sharing_plan (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_data_sharing_plan_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_data_sharing_plan_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_data_sharing_plan_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_data_sharing_plan_id_seq OWNED BY public.vocabulary_data_sharing_plan.id;
+
+
+--
+
+-- Name: vocabulary_data_sharing_plan id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_data_sharing_plan ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_data_sharing_plan_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_data_sharing_plan vocabulary_data_sharing_plan_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_data_sharing_plan
+    ADD CONSTRAINT vocabulary_data_sharing_plan_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_health_condition_code_type.sql
+++ b/database/tables/vocabulary_health_condition_code_type.sql
@@ -1,0 +1,55 @@
+-- Name: vocabulary_health_condition_code_type; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_health_condition_code_type (
+    id integer NOT NULL,
+    code_type_en character varying(255),
+    code_type_pt character varying(255),
+    code_type_es character varying(255),
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_health_condition_code_type_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_health_condition_code_type_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_health_condition_code_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_health_condition_code_type_id_seq OWNED BY public.vocabulary_health_condition_code_type.id;
+
+
+--
+
+-- Name: vocabulary_health_condition_code_type id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_health_condition_code_type ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_health_condition_code_type_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_health_condition_code_type vocabulary_health_condition_code_type_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_health_condition_code_type
+    ADD CONSTRAINT vocabulary_health_condition_code_type_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_health_condition_code_vocabulary.sql
+++ b/database/tables/vocabulary_health_condition_code_vocabulary.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_health_condition_code_vocabulary; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_health_condition_code_vocabulary (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_health_condition_code_vocabulary_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_health_condition_code_vocabulary_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_health_condition_code_vocabulary_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_health_condition_code_vocabulary_id_seq OWNED BY public.vocabulary_health_condition_code_vocabulary.id;
+
+
+--
+
+-- Name: vocabulary_health_condition_code_vocabulary id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_health_condition_code_vocabulary ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_health_condition_code_vocabulary_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_health_condition_code_vocabulary vocabulary_health_condition_code_vocabulary_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_health_condition_code_vocabulary
+    ADD CONSTRAINT vocabulary_health_condition_code_vocabulary_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_institution.sql
+++ b/database/tables/vocabulary_institution.sql
@@ -1,0 +1,55 @@
+-- Name: vocabulary_institution; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_institution (
+    id integer NOT NULL,
+    name character varying(255),
+    address text,
+    state character varying(255),
+    city character varying(255),
+    country character varying(255),
+    institution_type character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_institution_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_institution_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_institution_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_institution_id_seq OWNED BY public.vocabulary_institution.id;
+
+
+--
+
+-- Name: vocabulary_institution id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_institution ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_institution_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_institution vocabulary_institution_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_institution
+    ADD CONSTRAINT vocabulary_institution_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_institution_type.sql
+++ b/database/tables/vocabulary_institution_type.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_institution_type; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_institution_type (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_institution_type_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_institution_type_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_institution_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_institution_type_id_seq OWNED BY public.vocabulary_institution_type.id;
+
+
+--
+
+-- Name: vocabulary_institution_type id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_institution_type ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_institution_type_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_institution_type vocabulary_institution_type_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_institution_type
+    ADD CONSTRAINT vocabulary_institution_type_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_intervention.sql
+++ b/database/tables/vocabulary_intervention.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_intervention; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_intervention (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_intervention_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_intervention_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_intervention_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_intervention_id_seq OWNED BY public.vocabulary_intervention.id;
+
+
+--
+
+-- Name: vocabulary_intervention id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_intervention ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_intervention_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_intervention vocabulary_intervention_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_intervention
+    ADD CONSTRAINT vocabulary_intervention_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_monetary_material_support_type.sql
+++ b/database/tables/vocabulary_monetary_material_support_type.sql
@@ -1,0 +1,55 @@
+-- Name: vocabulary_monetary_material_support_type; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_monetary_material_support_type (
+    id integer NOT NULL,
+    type_en character varying(255),
+    type_pt character varying(255),
+    type_es character varying(255),
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_monetary_material_support_type_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_monetary_material_support_type_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_monetary_material_support_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_monetary_material_support_type_id_seq OWNED BY public.vocabulary_monetary_material_support_type.id;
+
+
+--
+
+-- Name: vocabulary_monetary_material_support_type id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_monetary_material_support_type ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_monetary_material_support_type_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_monetary_material_support_type vocabulary_monetary_material_support_type_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_monetary_material_support_type
+    ADD CONSTRAINT vocabulary_monetary_material_support_type_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_outcome_type.sql
+++ b/database/tables/vocabulary_outcome_type.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_outcome_type; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_outcome_type (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_outcome_type_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_outcome_type_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_outcome_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_outcome_type_id_seq OWNED BY public.vocabulary_outcome_type.id;
+
+
+--
+
+-- Name: vocabulary_outcome_type id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_outcome_type ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_outcome_type_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_outcome_type vocabulary_outcome_type_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_outcome_type
+    ADD CONSTRAINT vocabulary_outcome_type_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_recruitment_age_unit.sql
+++ b/database/tables/vocabulary_recruitment_age_unit.sql
@@ -1,0 +1,53 @@
+-- Name: vocabulary_recruitment_age_unit; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_recruitment_age_unit (
+    id integer NOT NULL,
+    value character varying(50),
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_recruitment_age_unit_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_recruitment_age_unit_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_recruitment_age_unit_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_recruitment_age_unit_id_seq OWNED BY public.vocabulary_recruitment_age_unit.id;
+
+
+--
+
+-- Name: vocabulary_recruitment_age_unit id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_recruitment_age_unit ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_recruitment_age_unit_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_recruitment_age_unit vocabulary_recruitment_age_unit_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_recruitment_age_unit
+    ADD CONSTRAINT vocabulary_recruitment_age_unit_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_recruitment_status.sql
+++ b/database/tables/vocabulary_recruitment_status.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_recruitment_status; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_recruitment_status (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_recruitment_status_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_recruitment_status_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_recruitment_status_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_recruitment_status_id_seq OWNED BY public.vocabulary_recruitment_status.id;
+
+
+--
+
+-- Name: vocabulary_recruitment_status id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_recruitment_status ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_recruitment_status_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_recruitment_status vocabulary_recruitment_status_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_recruitment_status
+    ADD CONSTRAINT vocabulary_recruitment_status_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_secondary_identify_type.sql
+++ b/database/tables/vocabulary_secondary_identify_type.sql
@@ -1,0 +1,55 @@
+-- Name: vocabulary_secondary_identify_type; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_secondary_identify_type (
+    id integer NOT NULL,
+    type_en character varying(255),
+    type_pt character varying(255),
+    type_es character varying(255),
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_secondary_identify_type_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_secondary_identify_type_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_secondary_identify_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_secondary_identify_type_id_seq OWNED BY public.vocabulary_secondary_identify_type.id;
+
+
+--
+
+-- Name: vocabulary_secondary_identify_type id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_secondary_identify_type ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_secondary_identify_type_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_secondary_identify_type vocabulary_secondary_identify_type_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_secondary_identify_type
+    ADD CONSTRAINT vocabulary_secondary_identify_type_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_study_alocation.sql
+++ b/database/tables/vocabulary_study_alocation.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_study_alocation; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_study_alocation (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_study_alocation_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_study_alocation_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_study_alocation_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_study_alocation_id_seq OWNED BY public.vocabulary_study_alocation.id;
+
+
+--
+
+-- Name: vocabulary_study_alocation id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_alocation ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_study_alocation_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_study_alocation vocabulary_study_alocation_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_alocation
+    ADD CONSTRAINT vocabulary_study_alocation_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_study_type_expanded_access.sql
+++ b/database/tables/vocabulary_study_type_expanded_access.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_study_type_expanded_access; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_study_type_expanded_access (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_study_type_expanded_access_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_study_type_expanded_access_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_study_type_expanded_access_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_study_type_expanded_access_id_seq OWNED BY public.vocabulary_study_type_expanded_access.id;
+
+
+--
+
+-- Name: vocabulary_study_type_expanded_access id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_expanded_access ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_study_type_expanded_access_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_study_type_expanded_access vocabulary_study_type_expanded_access_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_expanded_access
+    ADD CONSTRAINT vocabulary_study_type_expanded_access_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_study_type_intervention_assignment.sql
+++ b/database/tables/vocabulary_study_type_intervention_assignment.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_study_type_intervention_assignment; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_study_type_intervention_assignment (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_study_type_intervention_assignment_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_study_type_intervention_assignment_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_study_type_intervention_assignment_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_study_type_intervention_assignment_id_seq OWNED BY public.vocabulary_study_type_intervention_assignment.id;
+
+
+--
+
+-- Name: vocabulary_study_type_intervention_assignment id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_intervention_assignment ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_study_type_intervention_assignment_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_study_type_intervention_assignment vocabulary_study_type_intervention_assignment_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_intervention_assignment
+    ADD CONSTRAINT vocabulary_study_type_intervention_assignment_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_study_type_masking.sql
+++ b/database/tables/vocabulary_study_type_masking.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_study_type_masking; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_study_type_masking (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_study_type_masking_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_study_type_masking_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_study_type_masking_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_study_type_masking_id_seq OWNED BY public.vocabulary_study_type_masking.id;
+
+
+--
+
+-- Name: vocabulary_study_type_masking id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_masking ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_study_type_masking_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_study_type_masking vocabulary_study_type_masking_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_masking
+    ADD CONSTRAINT vocabulary_study_type_masking_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_study_type_obs_study_design.sql
+++ b/database/tables/vocabulary_study_type_obs_study_design.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_study_type_obs_study_design; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_study_type_obs_study_design (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_study_type_obs_study_design_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_study_type_obs_study_design_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_study_type_obs_study_design_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_study_type_obs_study_design_id_seq OWNED BY public.vocabulary_study_type_obs_study_design.id;
+
+
+--
+
+-- Name: vocabulary_study_type_obs_study_design id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_obs_study_design ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_study_type_obs_study_design_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_study_type_obs_study_design vocabulary_study_type_obs_study_design_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_obs_study_design
+    ADD CONSTRAINT vocabulary_study_type_obs_study_design_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_study_type_phase.sql
+++ b/database/tables/vocabulary_study_type_phase.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_study_type_phase; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_study_type_phase (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_study_type_phase_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_study_type_phase_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_study_type_phase_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_study_type_phase_id_seq OWNED BY public.vocabulary_study_type_phase.id;
+
+
+--
+
+-- Name: vocabulary_study_type_phase id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_phase ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_study_type_phase_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_study_type_phase vocabulary_study_type_phase_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_phase
+    ADD CONSTRAINT vocabulary_study_type_phase_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_study_type_purpose.sql
+++ b/database/tables/vocabulary_study_type_purpose.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_study_type_purpose; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_study_type_purpose (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_study_type_purpose_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_study_type_purpose_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_study_type_purpose_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_study_type_purpose_id_seq OWNED BY public.vocabulary_study_type_purpose.id;
+
+
+--
+
+-- Name: vocabulary_study_type_purpose id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_purpose ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_study_type_purpose_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_study_type_purpose vocabulary_study_type_purpose_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_purpose
+    ADD CONSTRAINT vocabulary_study_type_purpose_pkey PRIMARY KEY (id);
+
+
+--

--- a/database/tables/vocabulary_study_type_temporality.sql
+++ b/database/tables/vocabulary_study_type_temporality.sql
@@ -1,0 +1,52 @@
+-- Name: vocabulary_study_type_temporality; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.vocabulary_study_type_temporality (
+    id integer NOT NULL,
+    choice_en character varying(255),
+    choice_pt character varying(255),
+    choice_es character varying(255),
+    is_active boolean DEFAULT true
+);
+
+
+--
+
+-- Name: vocabulary_study_type_temporality_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vocabulary_study_type_temporality_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+
+-- Name: vocabulary_study_type_temporality_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.vocabulary_study_type_temporality_id_seq OWNED BY public.vocabulary_study_type_temporality.id;
+
+
+--
+
+-- Name: vocabulary_study_type_temporality id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_temporality ALTER COLUMN id SET DEFAULT nextval('public.vocabulary_study_type_temporality_id_seq'::regclass);
+
+
+--
+
+-- Name: vocabulary_study_type_temporality vocabulary_study_type_temporality_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vocabulary_study_type_temporality
+    ADD CONSTRAINT vocabulary_study_type_temporality_pkey PRIMARY KEY (id);
+
+
+--

--- a/scripts/create_procedures.py
+++ b/scripts/create_procedures.py
@@ -1,0 +1,65 @@
+"""Author: Diego Tostes
+
+Apply stored procedure definitions to the database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from db_config import DatabaseConfig
+from sql_runner import execute_sql_files, iter_sql_files
+
+
+def resolve_procedures_dir() -> Path:
+    """Return the default directory for procedure SQL files."""
+
+    return Path(__file__).resolve().parent.parent / "database" / "procedures"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description="Apply procedure SQL scripts in order.")
+    parser.add_argument(
+        "--directory",
+        type=Path,
+        default=resolve_procedures_dir(),
+        help="Directory containing the procedure SQL files.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Optional JSON file with database credentials.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Python logging level (default: INFO).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: Path | None) -> DatabaseConfig:
+    """Load database configuration from file or environment variables."""
+
+    if config_path is not None:
+        return DatabaseConfig.from_json(config_path)
+    return DatabaseConfig.from_env()
+
+
+def main() -> None:
+    """Execute the stored procedures."""
+
+    args = parse_args()
+    logging.basicConfig(level=args.log_level.upper())
+    config = load_config(args.config)
+    sql_files = list(iter_sql_files(args.directory))
+    execute_sql_files(sql_files, config)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/create_tables.py
+++ b/scripts/create_tables.py
@@ -1,0 +1,65 @@
+"""Author: Diego Tostes
+
+Command line helper to execute all table definition scripts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from db_config import DatabaseConfig
+from sql_runner import execute_sql_files, iter_sql_files
+
+
+def resolve_tables_dir() -> Path:
+    """Return the default path for table definition files."""
+
+    return Path(__file__).resolve().parent.parent / "database" / "tables"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the script."""
+
+    parser = argparse.ArgumentParser(description="Apply table DDL scripts in order.")
+    parser.add_argument(
+        "--directory",
+        type=Path,
+        default=resolve_tables_dir(),
+        help="Directory containing the table SQL files.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Optional JSON configuration file with database credentials.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Python logging level (default: INFO).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: Path | None) -> DatabaseConfig:
+    """Load the database configuration from file or environment."""
+
+    if config_path is not None:
+        return DatabaseConfig.from_json(config_path)
+    return DatabaseConfig.from_env()
+
+
+def main() -> None:
+    """Script entry point."""
+
+    args = parse_args()
+    logging.basicConfig(level=args.log_level.upper())
+    config = load_config(args.config)
+    sql_files = list(iter_sql_files(args.directory))
+    execute_sql_files(sql_files, config)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/db_config.py
+++ b/scripts/db_config.py
@@ -1,0 +1,63 @@
+"""Author: Diego Tostes
+
+Database configuration utilities.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+
+@dataclass
+class DatabaseConfig:
+    """Simple container for PostgreSQL connection parameters."""
+
+    host: str = "localhost"
+    port: int = 5432
+    user: str = "postgres"
+    password: str = "postgres"
+    database: str = "postgres"
+
+    @classmethod
+    def from_env(cls) -> "DatabaseConfig":
+        """Build a configuration instance using environment variables if present."""
+
+        return cls(
+            host=os.getenv("DB_HOST", cls.host),
+            port=int(os.getenv("DB_PORT", cls.port)),
+            user=os.getenv("DB_USER", cls.user),
+            password=os.getenv("DB_PASSWORD", cls.password),
+            database=os.getenv("DB_NAME", cls.database),
+        )
+
+    @classmethod
+    def from_json(cls, path: Path) -> "DatabaseConfig":
+        """Load configuration values from a JSON file."""
+
+        with path.open("r", encoding="utf-8") as handle:
+            data: Dict[str, Any] = json.load(handle)
+        return cls(
+            host=data.get("host", cls.host),
+            port=int(data.get("port", cls.port)),
+            user=data.get("user", cls.user),
+            password=data.get("password", cls.password),
+            database=data.get("database", cls.database),
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a dictionary ready to be expanded as psycopg2 connection kwargs."""
+
+        return {
+            "host": self.host,
+            "port": self.port,
+            "user": self.user,
+            "password": self.password,
+            "dbname": self.database,
+        }
+
+
+DEFAULT_CONFIG = DatabaseConfig()

--- a/scripts/populate_data.py
+++ b/scripts/populate_data.py
@@ -1,0 +1,65 @@
+"""Author: Diego Tostes
+
+Load static data into the database using the populate scripts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from db_config import DatabaseConfig
+from sql_runner import execute_sql_files, iter_sql_files
+
+
+def resolve_populate_dir() -> Path:
+    """Return the default directory for populate SQL files."""
+
+    return Path(__file__).resolve().parent.parent / "database" / "populate"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(description="Populate reference data using SQL scripts.")
+    parser.add_argument(
+        "--directory",
+        type=Path,
+        default=resolve_populate_dir(),
+        help="Directory containing the populate SQL files.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Optional JSON file with database credentials.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Python logging level (default: INFO).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: Path | None) -> DatabaseConfig:
+    """Load configuration from JSON or the environment."""
+
+    if config_path is not None:
+        return DatabaseConfig.from_json(config_path)
+    return DatabaseConfig.from_env()
+
+
+def main() -> None:
+    """Apply populate scripts to the database."""
+
+    args = parse_args()
+    logging.basicConfig(level=args.log_level.upper())
+    config = load_config(args.config)
+    sql_files = list(iter_sql_files(args.directory))
+    execute_sql_files(sql_files, config)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/schema_versioning.py
+++ b/scripts/schema_versioning.py
@@ -1,0 +1,176 @@
+"""Author: Diego Tostes
+
+Simple schema version tracking based on SQL file hashes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+from db_config import DatabaseConfig
+from sql_runner import iter_sql_files, get_connection
+
+SCHEMA_VERSION_TABLE = "schema_version"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for schema tracking."""
+
+    parser = argparse.ArgumentParser(
+        description="Track SQL file hashes in the schema_version table."
+    )
+    parser.add_argument(
+        "directories",
+        nargs="+",
+        type=Path,
+        help="One or more directories containing SQL files to track.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Optional JSON file with database credentials.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Python logging level (default: INFO).",
+    )
+    parser.add_argument(
+        "--record",
+        action="store_true",
+        help="Persist missing or outdated hashes back to the database.",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: Path | None) -> DatabaseConfig:
+    """Load configuration from file or environment."""
+
+    if config_path is not None:
+        return DatabaseConfig.from_json(config_path)
+    return DatabaseConfig.from_env()
+
+
+def calculate_hash(path: Path) -> str:
+    """Compute a SHA256 hash for the given file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def ensure_table_exists(connection) -> None:
+    """Create the schema_version table if it is missing."""
+
+    ddl = f"""
+    CREATE TABLE IF NOT EXISTS {SCHEMA_VERSION_TABLE} (
+        id SERIAL PRIMARY KEY,
+        file_path TEXT NOT NULL UNIQUE,
+        file_hash TEXT NOT NULL,
+        applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(ddl)
+    connection.commit()
+
+
+def fetch_existing_hashes(connection) -> Dict[str, str]:
+    """Fetch stored hashes from the schema_version table."""
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"SELECT file_path, file_hash FROM {SCHEMA_VERSION_TABLE}"
+        )
+        rows = cursor.fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
+def gather_files(directories: Iterable[Path]) -> Dict[str, Path]:
+    """Collect SQL files from the provided directories."""
+
+    root = Path(__file__).resolve().parent.parent
+    files: Dict[str, Path] = {}
+    for directory in directories:
+        for sql_file in iter_sql_files(directory):
+            relative_path = sql_file.resolve().relative_to(root)
+            files[str(relative_path)] = sql_file
+    return files
+
+
+def classify_files(
+    files: Dict[str, Path],
+    stored_hashes: Dict[str, str],
+) -> Tuple[Dict[str, Path], Dict[str, Path], Dict[str, Path]]:
+    """Classify files as missing, outdated or up-to-date."""
+
+    missing: Dict[str, Path] = {}
+    outdated: Dict[str, Path] = {}
+    up_to_date: Dict[str, Path] = {}
+
+    for rel_path, sql_file in files.items():
+        file_hash = calculate_hash(sql_file)
+        stored_hash = stored_hashes.get(rel_path)
+        if stored_hash is None:
+            missing[rel_path] = sql_file
+        elif stored_hash != file_hash:
+            outdated[rel_path] = sql_file
+        else:
+            up_to_date[rel_path] = sql_file
+    return missing, outdated, up_to_date
+
+
+def record_hashes(connection, files: Dict[str, Path]) -> None:
+    """Insert or update file hashes in the schema_version table."""
+
+    with connection.cursor() as cursor:
+        for rel_path, sql_file in files.items():
+            file_hash = calculate_hash(sql_file)
+            cursor.execute(
+                f"""
+                INSERT INTO {SCHEMA_VERSION_TABLE} (file_path, file_hash)
+                VALUES (%s, %s)
+                ON CONFLICT (file_path)
+                DO UPDATE SET file_hash = EXCLUDED.file_hash, applied_at = NOW()
+                """,
+                (rel_path, file_hash),
+            )
+    connection.commit()
+
+
+def main() -> None:
+    """Entry point for the schema versioning helper."""
+
+    args = parse_args()
+    logging.basicConfig(level=args.log_level.upper())
+    config = load_config(args.config)
+    directories = [directory for directory in args.directories]
+    files = gather_files(directories)
+
+    with get_connection(config) as connection:
+        ensure_table_exists(connection)
+        stored_hashes = fetch_existing_hashes(connection)
+        missing, outdated, up_to_date = classify_files(files, stored_hashes)
+
+        logging.info("Up-to-date files: %s", len(up_to_date))
+        logging.info("Missing files: %s", len(missing))
+        logging.info("Outdated files: %s", len(outdated))
+
+        if args.record:
+            to_record = {**missing, **outdated}
+            if to_record:
+                logging.info("Recording %s file hashes in the database.", len(to_record))
+                record_hashes(connection, to_record)
+            else:
+                logging.info("No changes to record.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sql_runner.py
+++ b/scripts/sql_runner.py
@@ -1,0 +1,56 @@
+"""Author: Diego Tostes
+
+Helper utilities to execute SQL files against PostgreSQL.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, Iterator
+
+import psycopg2
+from psycopg2.extensions import connection as PgConnection
+
+from db_config import DatabaseConfig, DEFAULT_CONFIG
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@contextmanager
+def get_connection(config: DatabaseConfig = DEFAULT_CONFIG) -> Iterator[PgConnection]:
+    """Yield a psycopg2 connection using the provided configuration."""
+
+    connection = psycopg2.connect(**config.as_dict())
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def execute_sql_file(path: Path, connection: PgConnection) -> None:
+    """Execute all SQL statements contained in the given file."""
+
+    LOGGER.info("Executing SQL file: %s", path)
+    sql_text = path.read_text(encoding="utf-8")
+    with connection.cursor() as cursor:
+        cursor.execute(sql_text)
+    connection.commit()
+
+
+def execute_sql_files(paths: Iterable[Path], config: DatabaseConfig = DEFAULT_CONFIG) -> None:
+    """Execute multiple SQL files in a single database session."""
+
+    with get_connection(config) as connection:
+        for sql_path in paths:
+            execute_sql_file(sql_path, connection)
+
+
+def iter_sql_files(directory: Path) -> Iterable[Path]:
+    """Yield SQL files from a directory sorted alphabetically."""
+
+    for path in sorted(directory.glob("*.sql")):
+        if path.is_file():
+            yield path


### PR DESCRIPTION
## Summary
- split the original dump into schema definitions under `database/tables` and stored procedures under `database/procedures`
- extract table data and sequence set operations into dedicated files under `database/populate`
- add Python utilities for applying SQL files and tracking schema versions, along with an updated README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1491ba1c8327a7dc861944d514ff