### PR TITLE
Prioritize vocabulary table creation order

### DIFF
--- a/scripts/create_tables.py
+++ b/scripts/create_tables.py
@@ -40,6 +40,14 @@ def parse_args() -> argparse.Namespace:
         default="INFO",
         help="Python logging level (default: INFO).",
     )
+    parser.add_argument(
+        "--priority-prefix",
+        default="vocabulary_",
+        help=(
+            "Optional filename prefix to prioritize when executing table scripts "
+            "(default: vocabulary_)."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -57,7 +65,7 @@ def main() -> None:
     args = parse_args()
     logging.basicConfig(level=args.log_level.upper())
     config = load_config(args.config)
-    sql_files = list(iter_sql_files(args.directory))
+    sql_files = list(iter_sql_files(args.directory, args.priority_prefix))
     execute_sql_files(sql_files, config)
 
 

--- a/scripts/sql_runner.py
+++ b/scripts/sql_runner.py
@@ -48,9 +48,21 @@ def execute_sql_files(paths: Iterable[Path], config: DatabaseConfig = DEFAULT_CO
             execute_sql_file(sql_path, connection)
 
 
-def iter_sql_files(directory: Path) -> Iterable[Path]:
-    """Yield SQL files from a directory sorted alphabetically."""
+def iter_sql_files(
+    directory: Path, priority_prefix: str | None = "vocabulary_"
+) -> Iterable[Path]:
+    """Yield SQL files from a directory with optional prioritized prefix ordering."""
 
-    for path in sorted(directory.glob("*.sql")):
-        if path.is_file():
-            yield path
+    sql_files = [path for path in directory.glob("*.sql") if path.is_file()]
+
+    if priority_prefix:
+        prioritized = sorted(
+            (path for path in sql_files if path.name.startswith(priority_prefix))
+        )
+        others = sorted(
+            (path for path in sql_files if not path.name.startswith(priority_prefix))
+        )
+        yield from prioritized
+        yield from others
+    else:
+        yield from sorted(sql_files)


### PR DESCRIPTION
## Summary
- update `iter_sql_files` to prioritize files whose names start with a configurable prefix (defaulting to `vocabulary_`)
- allow `create_tables.py` to pass through a CLI option so vocabulary tables are enqueued before dependent tables

## Testing
- python scripts/create_tables.py --directory database/tables --priority-prefix vocabulary_ *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68dc1ce3c7f88327bd7d1de792452caa