### PR TITLE
Fix pg_get_functiondef call with regprocedure cast

### DIFF
--- a/scripts/sql_runner.py
+++ b/scripts/sql_runner.py
@@ -303,7 +303,9 @@ def execute_sql_file(path: Path, connection: PgConnection) -> None:
             oid_row = cursor.fetchone()
 
             if oid_row and oid_row[0] is not None:
-                cursor.execute("SELECT pg_get_functiondef(%s)", (oid_row[0],))
+                cursor.execute(
+                    "SELECT pg_get_functiondef(%s::regprocedure)", (oid_row[0],)
+                )
                 current_definition_row = cursor.fetchone()
                 current_definition = (
                     current_definition_row[0] if current_definition_row else None


### PR DESCRIPTION
## Summary
- cast the stored procedure signature placeholder to regprocedure when fetching definitions

## Testing
- python scripts/create_procedures.py *(fails: missing psycopg2 dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd43ae39f88327b551e27b43763a20